### PR TITLE
Fixed ArgumentNullException in GetAccountFromRecord

### DIFF
--- a/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/KeyChainAccountStore.cs
+++ b/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/KeyChainAccountStore.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Auth
 
 		Account GetAccountFromRecord (SecRecord r)
 		{
-			var serializedData = NSString.FromData (r.Generic, NSStringEncoding.UTF8);
+			var serializedData = NSString.FromData (r.ValueData, NSStringEncoding.UTF8);
 			return Account.Deserialize (serializedData);
 		}
 


### PR DESCRIPTION
GetAccountFromRecord always throws an exception if called by FindAccountsForService or FindAccount. The reason is that the wrong property of the queried record was being converted to a NSString, causing NSString.FromData always being called with null as data value.
